### PR TITLE
Resolve paths on clear

### DIFF
--- a/packages/qualia_reval/server/reval.js
+++ b/packages/qualia_reval/server/reval.js
@@ -132,6 +132,8 @@ export default {
     let files = this.revalFiles.find().fetch(),
         clearedFiles = [];
 
+    filePaths = filePaths.map(path => Utils.resolvePath(path));
+
     if (filePaths.length > 0) {
       files = files.filter(file => {
         return filePaths.includes(file.path);


### PR DESCRIPTION
If an editor `reload`s a file to reval using a relative path, it can't know the final path reval uses for the file. As a result, it can't clear that file. This change makes `reload` and `clear` behave the same way in handling input paths.