### PR TITLE
#30 Fix URL of Monaco Editor

### DIFF
--- a/packages/qualia_reval/server/editor/editor.html
+++ b/packages/qualia_reval/server/editor/editor.html
@@ -4,7 +4,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.js" type="text/javascript" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js" type="text/javascript" charset="utf-8"></script>
 
-    <script src="{{cdnURL}}/vs//loader.js" type="text/javascript" charset="utf-8"></script>
+    <script src="{{cdnURL}}/vs/loader.js" type="text/javascript" charset="utf-8"></script>
     <script type="text/javascript">
       window.revalFilePath = '{{filePath}}';
 


### PR DESCRIPTION
Fixed an issue when reval was activated and click on a template, caused a 404 error.
replaced ```//``` to ```/``` in ```editor.html```