### PR TITLE
Fix server crashing in Meteor 1.8.1

### DIFF
--- a/packages/qualia_reval/server/reval.js
+++ b/packages/qualia_reval/server/reval.js
@@ -32,9 +32,10 @@ export default {
 
   watchClientReload() {
     // Hack to get access to the autoupdate collection
-    let dummy = new Mongo.Collection('reval.dummy', {connection: null}),
-        ClientVersions = dummy._driver.noConnCollections['meteor_autoupdate_clientVersions']
-    ;
+    let dummy = new Mongo.Collection('reval.dummy', {connection: null});
+    dummy._driver.open('meteor_autoupdate_clientVersions');
+
+    let ClientVersions = dummy._driver.noConnCollections['meteor_autoupdate_clientVersions']
 
     ClientVersions.find({_id: 'version'}).observe({
       changed: () => {


### PR DESCRIPTION
This seems to fix the problem where the server would crash on startup in Meteor 1.8.1. I have not tested it thoroughly yet or at all on versions other than Meteor 1.8.1. See issue #33.