### PR TITLE
WIP: Add NeoVim plugin

### DIFF
--- a/plugins/neovim/Makefile
+++ b/plugins/neovim/Makefile
@@ -1,0 +1,5 @@
+all:
+
+link:
+	mkdir -p ${HOME}/.local/share/nvim/site/pack/user/start
+	ln -s ${PWD}/ ${HOME}/.local/share/nvim/site/pack/user/start/reval

--- a/plugins/neovim/README.md
+++ b/plugins/neovim/README.md
@@ -18,7 +18,10 @@ make link
 ## Use
 
 Begin by editing a given file that you will eventually want to `reval`. Once the
-edits are made, simply run `:Reval` (saving the file is not needed). If you need
-to send the reval request to a host other than `localhost:3000`, simply pass
-that argument to the command: `:Reval localhost:4000`. Subsequent uses of the
-`:Reval` invocation will use the same host.
+edits are made, simply run `:Reval` (saving the file is not needed). The plugin
+will search up for a `.revalrc` file that contains the reval host for it to send
+the updated file contents to. If no `.revalrc` file is found, the default host
+of `localhost:3000` is used. If you need to send the reval request to a host
+other than `localhost:3000`, simply pass that argument to the command: `:Reval localhost:4000`.
+If no `.revalrc` file is present, subsequent uses of the `:Reval` invocation
+will use the same host.

--- a/plugins/neovim/README.md
+++ b/plugins/neovim/README.md
@@ -1,0 +1,24 @@
+# NeoVim Plugin for reval
+
+## Dependencies
+
+* NeoVim >=0.6
+* `plenary.curl`
+
+## Installation
+
+Clone this repo and run
+
+```sh
+git clone https://github.com/qualialabs/reval
+cd plugins/neovim
+make link
+```
+
+## Use
+
+Begin by editing a given file that you will eventually want to `reval`. Once the
+edits are made, simply run `:Reval` (saving the file is not needed). If you need
+to send the reval request to a host other than `localhost:3000`, simply pass
+that argument to the command: `:Reval localhost:4000`. Subsequent uses of the
+`:Reval` invocation will use the same host.

--- a/plugins/neovim/lua/reval.lua
+++ b/plugins/neovim/lua/reval.lua
@@ -19,10 +19,11 @@ end
 local function find_up(path, file_to_find)
   local current_directory = Path:new(path)
   while true do
-    current_directory = current_directory:parent()
-    if current_directory == nil then
+    local parent_directory = current_directory:parent()
+    if tostring(parent_directory) == tostring(current_directory) then
       break
     end
+    current_directory = parent_directory
 
     local potential_file = current_directory:joinpath(file_to_find)
     if potential_file:exists() then

--- a/plugins/neovim/lua/reval.lua
+++ b/plugins/neovim/lua/reval.lua
@@ -1,4 +1,6 @@
 local curl = require'plenary.curl'
+local Job = require'plenary.job'
+local Path = require'plenary.path'
 
 M = {}
 
@@ -20,10 +22,31 @@ function M.reval(host)
   end
   last_host = host
 
-  local txt = buftxt()
-  local url = "http://" .. host .. "/reval/reload?filePath=" .. vim.fn.expand('%:p')
-  print(url)
-  curl.post(url, { raw_body = txt })
+  local file = Path:new(vim.fn.expand('%:p'))
+  local repo_root = table.concat(Job:new{
+    command = 'git',
+    args = {'rev-parse', '--show-toplevel'},
+    cwd = tostring(file:parent()),
+    enabled_recording = true,
+  }:sync(), '')
+  local file_relative_to_repo_root = file:make_relative(repo_root)
+  local file_relative_to_dev = '/src/qualia/' .. file_relative_to_repo_root
+
+  local url = "http://" .. host .. "/reval/reload?filePath=/" .. file_relative_to_dev
+  curl.post(url, {
+    raw_body = buftxt(),
+    callback = vim.schedule_wrap(function(result)
+      -- result = {
+      --   body = "",
+      --   exit = 0,
+      --   headers = { "Server: nginx/1.15.12", "Date: Tue, 12 Apr 2022 23:32:30 GMT", "Content-Length: 0", "Connection: keep-alive", "x-content-type-options: nosniff", "", "" },
+      --   status = 200
+      -- }
+      assert(result.exit == 0, "curl exited with a non-zero exit code:" .. result.exit)
+      assert(result.status == 200, "response returned non-200 status-code:" .. result.status)
+      print("done", file_relative_to_dev)
+    end)
+  })
 end
 
 return M

--- a/plugins/neovim/lua/reval.lua
+++ b/plugins/neovim/lua/reval.lua
@@ -32,7 +32,7 @@ function M.reval(host)
   local file_relative_to_repo_root = file:make_relative(repo_root)
   local file_relative_to_dev = '/src/qualia/' .. file_relative_to_repo_root
 
-  local url = "http://" .. host .. "/reval/reload?filePath=/" .. file_relative_to_dev
+  local url = "http://" .. host .. "/reval/reload?filePath=" .. file_relative_to_dev
   curl.post(url, {
     raw_body = buftxt(),
     callback = vim.schedule_wrap(function(result)

--- a/plugins/neovim/lua/reval.lua
+++ b/plugins/neovim/lua/reval.lua
@@ -1,0 +1,34 @@
+local curl = require'plenary.curl'
+
+M = {}
+
+local last_host = "localhost:3000"
+
+local function buftxt()
+  local buf_no = vim.api.nvim_win_get_buf(0)
+  local lines = vim.api.nvim_buf_get_lines(buf_no, 0, vim.api.nvim_buf_line_count(buf_no), true)
+  local s = ''
+  for _, line in ipairs(lines) do
+    s = s .. line .. '\n'
+  end
+  return s
+end
+
+function M.reval(host)
+  if host == nil or host == "" then
+    host = last_host
+  end
+  last_host = host
+
+  local txt = buftxt()
+  local url = "http://" .. host .. "/reval/reload?filePath=" .. vim.fn.expand('%:p')
+  print(url)
+  curl.post(url, {
+    raw_body = txt,
+    callback = vim.schedule_wrap(function()
+      print("reval'd '" .. vim.fn.expand('%'), "'")
+    end)
+  })
+end
+
+return M

--- a/plugins/neovim/lua/reval.lua
+++ b/plugins/neovim/lua/reval.lua
@@ -16,13 +16,32 @@ local function buftxt()
   return s
 end
 
+local function find_up(path, file_to_find)
+  local current_directory = Path:new(path)
+  while true do
+    current_directory = current_directory:parent()
+    if current_directory == nil then
+      break
+    end
+
+    local potential_file = current_directory:joinpath(file_to_find)
+    if potential_file:exists() then
+      return Path:new(potential_file:absolute())
+    end
+  end
+end
+
 function M.reval(host)
-  if host == nil or host == "" then
-    host = last_host
+  local file = Path:new(vim.fn.expand('%:p'))
+  local revalrc = find_up(tostring(file), ".revalrc")
+
+  if (host == nil or host == "") and revalrc:exists() then
+    host = revalrc:read()
+  elseif host == nil or host == "" then
+      host = last_host
   end
   last_host = host
 
-  local file = Path:new(vim.fn.expand('%:p'))
   local repo_root = table.concat(Job:new{
     command = 'git',
     args = {'rev-parse', '--show-toplevel'},
@@ -35,6 +54,7 @@ function M.reval(host)
   local url = "http://" .. host .. "/reval/reload?filePath=" .. file_relative_to_dev
   curl.post(url, {
     raw_body = buftxt(),
+    raw = { "-m", "5" },
     callback = vim.schedule_wrap(function(result)
       -- result = {
       --   body = "",
@@ -44,7 +64,7 @@ function M.reval(host)
       -- }
       assert(result.exit == 0, "curl exited with a non-zero exit code:" .. result.exit)
       assert(result.status == 200, "response returned non-200 status-code:" .. result.status)
-      print("done", file_relative_to_dev)
+      print("reval'd", file_relative_to_dev, "at", host)
     end)
   })
 end

--- a/plugins/neovim/lua/reval.lua
+++ b/plugins/neovim/lua/reval.lua
@@ -23,12 +23,7 @@ function M.reval(host)
   local txt = buftxt()
   local url = "http://" .. host .. "/reval/reload?filePath=" .. vim.fn.expand('%:p')
   print(url)
-  curl.post(url, {
-    raw_body = txt,
-    callback = vim.schedule_wrap(function()
-      print("reval'd '" .. vim.fn.expand('%'), "'")
-    end)
-  })
+  curl.post(url, { raw_body = txt })
 end
 
 return M

--- a/plugins/neovim/plugin/reval/reval.vim
+++ b/plugins/neovim/plugin/reval/reval.vim
@@ -1,0 +1,1 @@
+command! -nargs=* Reval :lua require'reval'.reval('<args>')


### PR DESCRIPTION
I'm going through the engineering challenges, and I noticed (to the best of my knowledge), that NeoVim does not have a reval plugin.  After perusing the other plugins' source, I noticed that the server has a very simple REST API and implemented a client for it in NeoVim (Lua) using plenary.nvim's built-in `curl` client.

For now, I stored the plugin's source in a subfolder of this repo, which makes installation using one of the many NeoVim package managers non-idiomatic: in fact, I believe none of them support installation of plugins from sub-folders, to the best of my knowledge. In light of this fact, it would be best to move this plugin into its own repository.  Barring that, there is a simple Makefile with a task to ease installing this plugin from this repo's source (`cd plugins/neovim && make link`).